### PR TITLE
DeviceModel from CommonTypes

### DIFF
--- a/Sources/StandardPairingUI/Assets/DeviceImages.swift
+++ b/Sources/StandardPairingUI/Assets/DeviceImages.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 import SwiftUI
-import Tomonari
+import CommonTypes
 
 enum DeviceImages {
     static func image(for codeName: String) -> Image {


### PR DESCRIPTION
Previously device model code names were loaded from Tomonari, now it should be loaded from CommonTypes as it is the correct place for this info now.