### PR TITLE
Switched EnvironmentObjects to Environment keys with default values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "StandardPairingUI",
     // The supported platform version here couldn't be lower than in Tomonari.
     platforms: [
-        .iOS("14.5.0"),
+        .iOS("16.6"),
         .macOS(.v10_15),
     ],
     products: [

--- a/Sources/StandardPairingUI/Theme/ThemeManager.swift
+++ b/Sources/StandardPairingUI/Theme/ThemeManager.swift
@@ -12,19 +12,32 @@ public class ThemeManager: ObservableObject {
     public func setTheme(_ theme: ThemeProtocol) {
         selectedTheme = theme
     }
+    
+    internal static var namiDefault: ThemeManager { ThemeManager(selectedTheme: NamiTheme()) }
+}
+
+private struct ThemeManagerKey: EnvironmentKey {
+    static let defaultValue: ThemeManager = .namiDefault
+}
+
+public extension EnvironmentValues {
+    var themeManager: ThemeManager {
+        get { self[ThemeManagerKey.self] }
+        set { self[ThemeManagerKey.self] = newValue }
+    }
 }
 
 struct NamiNavBar: ViewModifier {
     init() {
-        UINavigationBar.appearance().largeTitleTextAttributes = [.font: themeManager.selectedTheme.headline4]
-        UINavigationBar.appearance().titleTextAttributes = [.font: themeManager.selectedTheme.headline4]
+        UINavigationBar.appearance().largeTitleTextAttributes = [.font: (themeManager ?? .namiDefault).selectedTheme.headline4]
+        UINavigationBar.appearance().titleTextAttributes = [.font: (themeManager ?? .namiDefault).selectedTheme.headline4]
     }
     
     func body(content: Content) -> some View {
         content
     }
     
-    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.themeManager) private var themeManager
 }
 
 extension View {

--- a/Sources/StandardPairingUI/Views/BluetoothDeviceFoundView.swift
+++ b/Sources/StandardPairingUI/Views/BluetoothDeviceFoundView.swift
@@ -48,8 +48,8 @@ public struct BluetoothDeviceFoundView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: BluetoothDeviceFound.ViewModel       
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     // MARK: Private
     @State private var isKeyboardAppeared: Bool = false

--- a/Sources/StandardPairingUI/Views/EnableCameraInSettingsView.swift
+++ b/Sources/StandardPairingUI/Views/EnableCameraInSettingsView.swift
@@ -44,8 +44,8 @@ public struct EnableCameraInSettingsView: View {
         .ignoresSafeArea(.keyboard)
     }
     
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     // MARK: Private
 

--- a/Sources/StandardPairingUI/Views/EnterWiFiPasswordView.swift
+++ b/Sources/StandardPairingUI/Views/EnterWiFiPasswordView.swift
@@ -85,8 +85,8 @@ public struct EnterWiFiPasswordView: View {
     @ObservedObject var viewModel: EnterWiFiPassword.ViewModel
     @State var textIsEditing = true
     @State private var isKeyboardAppeared: Bool = false
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     
     private func navigationTitle() -> String {
         if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty {

--- a/Sources/StandardPairingUI/Views/FinishingSetupView.swift
+++ b/Sources/StandardPairingUI/Views/FinishingSetupView.swift
@@ -35,8 +35,8 @@ public struct FinishingSetupView: View {
         .allowSwipeBackNavigation(false)
     }
     
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     
     private var title: String
     

--- a/Sources/StandardPairingUI/Views/ListWiFiNetworksView.swift
+++ b/Sources/StandardPairingUI/Views/ListWiFiNetworksView.swift
@@ -85,8 +85,8 @@ public struct ListWiFiNetworksView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: ListWiFiNetworks.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     // MARK: Private
     

--- a/Sources/StandardPairingUI/Views/OtherWiFiNetworkView.swift
+++ b/Sources/StandardPairingUI/Views/OtherWiFiNetworkView.swift
@@ -98,8 +98,8 @@ public struct OtherWiFiNetworkView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: OtherWiFiNetwork.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     @State var nameIsEditing = true
     @State var passwordIsEditing = false
     @State private var isKeyboardAppeared: Bool = false

--- a/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
+++ b/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
@@ -102,8 +102,8 @@ public struct PairingErrorScreenView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: PairingErrorScreen.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     @State private var primaryButtonIndex = 0
 
     // MARK: Private

--- a/Sources/StandardPairingUI/Views/PowerOnAndScanningView.swift
+++ b/Sources/StandardPairingUI/Views/PowerOnAndScanningView.swift
@@ -36,8 +36,8 @@ public struct PowerOnAndScanningView: View {
 
     @ObservedObject var viewModel: PowerOnAndScanning.ViewModel
     
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     
     private func navigationBarTitle() -> String {
         if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 

--- a/Sources/StandardPairingUI/Views/QRScannerView.swift
+++ b/Sources/StandardPairingUI/Views/QRScannerView.swift
@@ -124,8 +124,8 @@ public struct QRScannerView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: QRScanner.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     @State var bottomSheetHeight: CGFloat = 0
     @State var shouldShowQRcodeLocation = true
 

--- a/Sources/StandardPairingUI/Views/Supporting Views/DevicePresentingLoadingView.swift
+++ b/Sources/StandardPairingUI/Views/Supporting Views/DevicePresentingLoadingView.swift
@@ -38,8 +38,8 @@ struct DevicePresentingLoadingView: View {
 
     // MARK: Private
     
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     private var deviceName: String
     private var deviceModel: NamiDeviceModel
 }

--- a/Sources/StandardPairingUI/Views/Supporting Views/DeviceSetupScreen.swift
+++ b/Sources/StandardPairingUI/Views/Supporting Views/DeviceSetupScreen.swift
@@ -28,7 +28,7 @@ public struct DeviceSetupScreen<LeadingGroup: View, Subview: View, BottomGroup: 
 
     public var body: some View {
         ZStack {
-            themeManager.selectedTheme.background
+            (themeManager ?? .namiDefault).selectedTheme.background
                 .edgesIgnoringSafeArea(.all)
             VStack(spacing: 0) {
                 subview()
@@ -43,8 +43,8 @@ public struct DeviceSetupScreen<LeadingGroup: View, Subview: View, BottomGroup: 
             ToolbarItem(placement: .principal) { 
                 VStack {
                     Text(title)
-                        .font(themeManager.selectedTheme.headline5)
-                        .foregroundColor(themeManager.selectedTheme.navigationTitleColor)
+                        .font((themeManager ?? .namiDefault).selectedTheme.headline5)
+                        .foregroundColor((themeManager ?? .namiDefault).selectedTheme.navigationTitleColor)
                 }
             }
         }
@@ -54,7 +54,7 @@ public struct DeviceSetupScreen<LeadingGroup: View, Subview: View, BottomGroup: 
 
     // MARK: Private
 
-    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.themeManager) private var themeManager
     private let title: String
     private let subview: () -> Subview
     private var leadingButtonsGroup: () -> LeadingGroup

--- a/Sources/StandardPairingUI/Views/Supporting Views/SetupScreenTitleTextView.swift
+++ b/Sources/StandardPairingUI/Views/Supporting Views/SetupScreenTitleTextView.swift
@@ -26,7 +26,7 @@ public struct SetupScreenTitleTextView: View {
         .frame(minWidth: 200)
     }
     
-    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.themeManager) private var themeManager
 }
 
 // MARK: - ScreenTitleTextView_Previews

--- a/Sources/StandardPairingUI/Views/Supporting Views/SetupTopNavigationBar.swift
+++ b/Sources/StandardPairingUI/Views/Supporting Views/SetupTopNavigationBar.swift
@@ -45,7 +45,7 @@ public struct SetupTopNavigationBar<LeadingGroup: View, TrailingGroup: View, Not
     var subviews: () -> Subviews
     
     @State private var notificationAreaHeight: CGFloat = 0
-    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.themeManager) private var themeManager
     
     public var body: some View {
         VStack(spacing: 0) {

--- a/Sources/StandardPairingUI/Views/Supporting Views/WiFiNetworkRowView.swift
+++ b/Sources/StandardPairingUI/Views/Supporting Views/WiFiNetworkRowView.swift
@@ -35,7 +35,7 @@ struct WiFiNetworkRowView: View {
 
     // MARK: Private
     
-    @EnvironmentObject private var themeManager: ThemeManager
+    @Environment(\.themeManager) private var themeManager
 
     private func wifiImage() -> some View {
         if network.rssi >= -45 {

--- a/Sources/StandardPairingUI/Views/WiDAR/ErrorScreenView.swift
+++ b/Sources/StandardPairingUI/Views/WiDAR/ErrorScreenView.swift
@@ -15,8 +15,8 @@ public struct ErrorScreenView: View {
     // MARK: Internal
 
     @ObservedObject var viewModel: ErrorScreen.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     public var body: some View {
         DeviceSetupScreen(title: wordingManager.wordings.positioningNavigationTitle) {

--- a/Sources/StandardPairingUI/Views/WiDAR/HowToPositionView.swift
+++ b/Sources/StandardPairingUI/Views/WiDAR/HowToPositionView.swift
@@ -19,8 +19,8 @@ public struct HowToPositionView: View {
     @Environment(\.animations) var animations: Animations
     
     @ObservedObject var viewModel: HowToPosition.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
     
     public var body: some View {
         DeviceSetupScreen(title: wordingManager.wordings.positioningNavigationTitle) {

--- a/Sources/StandardPairingUI/Views/WiDAR/InitialScreenView.swift
+++ b/Sources/StandardPairingUI/Views/WiDAR/InitialScreenView.swift
@@ -18,8 +18,8 @@ public struct InitialScreenView: View {
 
     @ObservedObject var viewModel: InitialScreen.ViewModel
     @Environment(\.colors) var colors: Colors
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     public var body: some View {
         DeviceSetupScreen(title: wordingManager.wordings.positioningNavigationTitle) {

--- a/Sources/StandardPairingUI/Views/WiDAR/PositioningCompleteView.swift
+++ b/Sources/StandardPairingUI/Views/WiDAR/PositioningCompleteView.swift
@@ -17,8 +17,8 @@ public struct PositioningCompleteView: View {
     @Environment(\.animations) var animations: Animations
 
     @ObservedObject var viewModel: PositioningComplete.ViewModel
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     public var body: some View {
         DeviceSetupScreen(title: wordingManager.wordings.positioningNavigationTitle) {

--- a/Sources/StandardPairingUI/Views/WiDAR/PositioningGuidanceView.swift
+++ b/Sources/StandardPairingUI/Views/WiDAR/PositioningGuidanceView.swift
@@ -20,8 +20,8 @@ public struct PositioningGuidanceView: View {
     @Environment(\.animations) var animations: Animations
     @Environment(\.colors) var colors: Colors
     @Environment(\.measurementSystem) var measurementSystem: MeasurementSystem
-    @EnvironmentObject private var themeManager: ThemeManager
-    @EnvironmentObject private var wordingManager: WordingManager
+    @Environment(\.themeManager) private var themeManager
+    @Environment(\.wordingManager) private var wordingManager
 
     @ObservedObject var viewModel: PositioningGuidance.ViewModel
 

--- a/Sources/StandardPairingUI/Wording/WordingManager.swift
+++ b/Sources/StandardPairingUI/Wording/WordingManager.swift
@@ -27,6 +27,17 @@ public class WordingManager: ObservableObject {
     }
 }
 
+private struct WordingManagerKey: EnvironmentKey {
+    static let defaultValue: WordingManager = WordingManager()
+}
+
+public extension EnvironmentValues {
+    var wordingManager: WordingManager {
+        get { self[WordingManagerKey.self] }
+        set { self[WordingManagerKey.self] = newValue }
+    }
+}
+
 private struct DefaultWordings: WordingProtocol {
     var pairingNavigationBarTitle: String = I18n.pairingDeviceSetupNavigagtionTitle
     


### PR DESCRIPTION
Before even for standard views the user had to pass the environment objects when getting the pairing View, otherwise the app was crashing.
```swift
sdk.startPairing(
                placeId: placeId,
                zoneId: zoneId,
                roomId: roomId,
                pairingSteps: ViewsContainer()
)
.environmentObject(ThemeManager(selectedTheme: NamiTheme()))
.environmentObject(WordingManager())
```
With this change there's always a default ThemeManager and WordingManager stored in package provided environment.
At the same time the library consumer is able to provide own implementation but **doesn't have to** by setting the environment keys with own values:
```swift
sdk.startPairing(
                placeId: placeId,
                zoneId: zoneId,
                roomId: roomId,
                pairingSteps: ViewsContainer()
)
.environment(\.themeManager, ThemeManager(selectedTheme: NamiTheme()))
.environment(\.wordingManager, WordingManager())
```
It makes the usage of default implementation less errors prone and cause less questions about why it might crash.

Tests? Nada.
I only tested it works with and without the default implementation provided but haven't checked the non-standard implementation really overrides the defaults.