### PR TITLE
fixed the issue with error description for the device type mismatch when commissioning the kit

### DIFF
--- a/Sources/StandardPairingUI/PairingErrorsWordings.swift
+++ b/Sources/StandardPairingUI/PairingErrorsWordings.swift
@@ -79,8 +79,12 @@ extension PairingMachineError {
             return wordings.pairingErrorDeserializationDescription
         case .encryptionError:
             return wordings.pairingErrorEncryptionErrorDescription
-        case let .notSupportDeviceType(deviceType):
-            return wordings.pairingErrorDeviceMismatchDescription
+        case .notSupportDeviceType(_):
+            if isSettingUpKit(wordings: wordings) {
+                return wordings.pairingErrorKitDeviceMismatchDescription
+            } else {
+                return wordings.pairingErrorDeviceMismatchDescription
+            }
         case .connectionTimeOutError:
             return wordings.pairingErrorConnectionTimeoutDescription
         case let .bluetoothDisconnectedError(deviceType, canTryAgain):

--- a/Sources/StandardPairingUI/Utilities/KitSetup.swift
+++ b/Sources/StandardPairingUI/Utilities/KitSetup.swift
@@ -1,0 +1,14 @@
+//
+//  KitSetup.swift
+//  StandardPairingUI
+//
+//  Created by Gleb Vodovozov on 10/2/25.
+//
+
+func isSettingUpKit(wordings: WordingProtocol) -> Bool {
+    return wordings.pairingNavigationBarTitle.isEmpty
+}
+
+func kitName(wordings: WordingProtocol) -> String {
+    return wordings.pairingNavigationBarTitle
+}

--- a/Sources/StandardPairingUI/Views/BluetoothDeviceFoundView.swift
+++ b/Sources/StandardPairingUI/Views/BluetoothDeviceFoundView.swift
@@ -56,8 +56,8 @@ public struct BluetoothDeviceFoundView: View {
     @State private var isEditing: Bool = true
 
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         if let deviceModel = viewModel.state.deviceModel, deviceModel.deviceType != .unknown {

--- a/Sources/StandardPairingUI/Views/EnableCameraInSettingsView.swift
+++ b/Sources/StandardPairingUI/Views/EnableCameraInSettingsView.swift
@@ -9,7 +9,7 @@ public struct EnableCameraInSettingsView: View {
     }
     
     public var body: some View {
-        DeviceSetupScreen(title: !wordingManager.wordings.pairingNavigationBarTitle.isEmpty ? wordingManager.wordings.pairingNavigationBarTitle : self.deviceType) {
+        DeviceSetupScreen(title: isSettingUpKit(wordings: wordingManager.wordings) ? kitName(wordings: wordingManager.wordings) : self.deviceType) {
             VStack {
                 Text(wordingManager.wordings.scanQRtitle)
                     .font(themeManager.selectedTheme.headline3)

--- a/Sources/StandardPairingUI/Views/EnterWiFiPasswordView.swift
+++ b/Sources/StandardPairingUI/Views/EnterWiFiPasswordView.swift
@@ -89,8 +89,8 @@ public struct EnterWiFiPasswordView: View {
     @EnvironmentObject private var wordingManager: WordingManager
     
     private func navigationTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty {
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return viewModel.state.deviceType != .unknown ? viewModel.state.deviceType.localizedName : I18n.pairingDeviceSetupNavigagtionTitle

--- a/Sources/StandardPairingUI/Views/FinishingSetupView.swift
+++ b/Sources/StandardPairingUI/Views/FinishingSetupView.swift
@@ -41,8 +41,8 @@ public struct FinishingSetupView: View {
     private var title: String
     
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty {
-            return wordingManager.wordings.pairingNavigationBarTitle 
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return self.title.isEmpty ? I18n.pairingDeviceSetupNavigationTitle : self.title

--- a/Sources/StandardPairingUI/Views/ListWiFiNetworksView.swift
+++ b/Sources/StandardPairingUI/Views/ListWiFiNetworksView.swift
@@ -91,8 +91,8 @@ public struct ListWiFiNetworksView: View {
     // MARK: Private
     
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return viewModel.state.deviceType != .unknown ? viewModel.state.deviceType.localizedName : I18n.pairingDeviceSetupNavigationTitle

--- a/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
+++ b/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
@@ -109,8 +109,8 @@ public struct PairingErrorScreenView: View {
     // MARK: Private
 
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return viewModel.state.deviceType != .unknown ? viewModel.state.deviceType.localizedName : I18n.pairingDeviceSetupNavigationTitle
@@ -124,11 +124,11 @@ public struct PairingErrorScreenView: View {
             if let error = error as? PairingMachineError, case .notSupportDeviceType(_) = error {
                 // Hacky way of handling if this is a kit system is currently being set up
                 // Skip rendering if the action is `.restart` and `pairingNavigationBarTitle` is not empty
-                if action == .restart && !wordingManager.wordings.pairingNavigationBarTitle.isEmpty {
+                if action == .restart && isSettingUpKit(wordings: wordingManager.wordings) {
                     return EmptyView().anyView
                 }
                 
-                if action == .tryAgain && wordingManager.wordings.pairingNavigationBarTitle.isEmpty {
+                if action == .tryAgain && !isSettingUpKit(wordings: wordingManager.wordings) {
                     primaryButtonIndex += 1
                     return EmptyView().anyView
                 }
@@ -149,7 +149,11 @@ public struct PairingErrorScreenView: View {
         case .tryAgain:
             if case let .underlying(error) = viewModel.state.error {
                 if let error = error as? PairingMachineError, case .notSupportDeviceType(_) = error {
-                    return wordingManager.wordings.scanDeviceAgainActionTitle
+                    if isSettingUpKit(wordings: wordingManager.wordings) {
+                        return wordingManager.wordings.scanDeviceAgainActionTitle
+                    } else {
+                        return wordingManager.wordings.restartSetupActionTitle
+                    }
                 }
             } 
             

--- a/Sources/StandardPairingUI/Views/PowerOnAndScanningView.swift
+++ b/Sources/StandardPairingUI/Views/PowerOnAndScanningView.swift
@@ -40,8 +40,8 @@ public struct PowerOnAndScanningView: View {
     @EnvironmentObject private var wordingManager: WordingManager
     
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return viewModel.state.deviceType != .unknown ? viewModel.state.deviceType.localizedName : I18n.pairingDeviceSetupNavigationTitle

--- a/Sources/StandardPairingUI/Views/QRScannerView.swift
+++ b/Sources/StandardPairingUI/Views/QRScannerView.swift
@@ -132,8 +132,8 @@ public struct QRScannerView: View {
     // MARK: Private
     
     private func navigationBarTitle() -> String {
-        if !wordingManager.wordings.pairingNavigationBarTitle.isEmpty { 
-            return wordingManager.wordings.pairingNavigationBarTitle
+        if isSettingUpKit(wordings: wordingManager.wordings) {
+            return kitName(wordings: wordingManager.wordings)
         }
         
         return viewModel.state.deviceType != .unknown ? viewModel.state.deviceType.localizedName : I18n.pairingDeviceSetupNavigationTitle

--- a/Sources/StandardPairingUI/Wording/WordingProtocol.swift
+++ b/Sources/StandardPairingUI/Wording/WordingProtocol.swift
@@ -178,6 +178,7 @@ public protocol WordingProtocol {
     var pairingErrorDeserializationDescription: String { get }
     var pairingErrorEncryptionErrorDescription: String { get }
     var pairingErrorDeviceMismatchDescription: String { get }
+    var pairingErrorKitDeviceMismatchDescription: String { get }
     var pairingErrorConnectionTimeoutDescription: String { get }
     func pairingErrorBleDisconnectedDescription(deviceName: String) -> String 
     var pairingErrorDeviceSecureSessionDescription: String { get }

--- a/Sources/StandardPairingUI/Wording/WordingProtocolExtension.swift
+++ b/Sources/StandardPairingUI/Wording/WordingProtocolExtension.swift
@@ -179,6 +179,7 @@ public extension WordingProtocol {
     var pairingErrorDeserializationDescription: String { get { return I18n.errorsPairingMachineDeserializationError } }
     var pairingErrorEncryptionErrorDescription: String { get { return I18n.errorsPairingMachineEncryptionError } }
     var pairingErrorDeviceMismatchDescription: String { get { return I18n.pairingErrorsDeviceSetupErrorDeviceMismatchDescription } }
+    var pairingErrorKitDeviceMismatchDescription: String { get { return I18n.pairingErrorsThreadSetupErrorDeviceMismatchDescription } }
     var pairingErrorConnectionTimeoutDescription: String { get { return I18n.errorsPairingConnectionTimeOutDescription }}
     func pairingErrorBleDisconnectedDescription(deviceName: String) -> String { return I18n.errorsPairingBleDisconnectedDescription(deviceName) }
     var pairingErrorDeviceSecureSessionDescription: String { get { return I18n.errorsPairingErrorDeviceSecureSessionError } }


### PR DESCRIPTION
Additionally, extracted the function of detecting whether we're pairing a single device or a kit. It will be easier to refactor it in the future