### PR TITLE
[TODO-2565] use the same content of no thread network error for all devices

### DIFF
--- a/Sources/StandardPairingUI/PairingErrorsExtensions.swift
+++ b/Sources/StandardPairingUI/PairingErrorsExtensions.swift
@@ -101,12 +101,7 @@ extension Pairing.ThreadError {
         case .threadOperationalDatasetMissing:
             return I18n.errorsPairingThreadSetupErrorThreadOperationalDatasetMissing
         case let .threadNetworkNotFound(zoneName, deviceType):
-            switch deviceType {
-            case .contactSensor:
-                return I18n.pairingErrorsContactSensorSetupErrorNoThreadNetworksFoundDescription1(zoneName)
-            default:
-                return I18n.pairingErrorsThreadSetupErrorNoThreadNetworksFoundDescription(zoneName)
-            }
+            return I18n.pairingErrorsThreadSetupErrorNoThreadNetworksFoundDescription(zoneName)
         }
     }
 }

--- a/Sources/StandardPairingUI/PairingErrorsWordings.swift
+++ b/Sources/StandardPairingUI/PairingErrorsWordings.swift
@@ -134,12 +134,7 @@ extension Pairing.ThreadError {
         case .threadOperationalDatasetMissing:
             return wordings.pairingThreadErrorDatasetMissingDescription
         case let .threadNetworkNotFound(zoneName, deviceType):
-            switch deviceType {
-            case .contactSensor:
-                return wordings.pairingThreadErrorContactSensorNoThreadNetworksFoundDescription1(zoneName: zoneName)
-            default:
-                return wordings.pairingThreadErrorNoThreadNetworksFoundDescription(zoneName: zoneName)
-            }
+            return wordings.pairingThreadErrorNoThreadNetworksFoundDescription(zoneName: zoneName)
         }
     }
 }

--- a/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
+++ b/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
@@ -44,14 +44,6 @@ public struct PairingErrorScreenView: View {
                         .padding(.top, 4)
                         .lineLimit(4)
                         .fixedSize(horizontal: false, vertical: true)
-                    Text(wordingManager.wordings.pairingThreadErrorContactSensorNoThreadNetworksFoundDescription2)
-                        .font(themeManager.selectedTheme.paragraph1)
-                        .foregroundColor(themeManager.selectedTheme.primaryBlack)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal)
-                        .padding(.top, 2)
-                        .lineLimit(4)
-                        .fixedSize(horizontal: false, vertical: true)
                 } else {
                     switch viewModel.state.error {
                     case .underlying(PairingMachineError.unexpectedState): 


### PR DESCRIPTION
We'd like to use the same content of No thread network found error for all devices.