### PR TITLE
Exit setup button appearance elevated to secondary

### DIFF
--- a/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
+++ b/Sources/StandardPairingUI/Views/PairingErrorScreenView.swift
@@ -134,7 +134,7 @@ public struct PairingErrorScreenView: View {
         
         let style = action != .exit ? 
             themeManager.selectedTheme.primaryActionButtonStyle 
-        : viewModel.state.actions.count == 1 ? themeManager.selectedTheme.primaryActionButtonStyle : themeManager.selectedTheme.tertiaryActionButtonStyle
+        : viewModel.state.actions.count == 1 ? themeManager.selectedTheme.primaryActionButtonStyle : themeManager.selectedTheme.secondaryActionButtonStyle
         
         return Button(titleForAction(action), action: { viewModel.send(event: .didChooseAction(action)) })
             .disabled(viewModel.state.chosenAction != nil)


### PR DESCRIPTION
Fixes to comply with comment in https://www.notion.so/Error-screen-x-QR-code-error-Wrong-background-color-for-Exit-setup-button-25a22fe13e448054b003e7f1b6840b4e?v=22c22fe13e44808e9a32000c1905dc4f&source=copy_link.